### PR TITLE
Automate PR creation in refactor pipeline

### DIFF
--- a/common/utils/churn_utils.py
+++ b/common/utils/churn_utils.py
@@ -69,6 +69,6 @@ def calculate_repo_churn_scores(file_histories: Dict[str, List[Dict[str, str]]],
 
     for file_path, history in file_histories.items():
         # The file-level calculation also filters by 'since', so we pass it down.
-        churn_scores[file_path.replace('/', '\\')] = calculate_file_churn_score(history, total_repo_commits, since)
+        churn_scores[file_path] = calculate_file_churn_score(history, total_repo_commits, since)
 
     return churn_scores

--- a/refactor/requirements.txt
+++ b/refactor/requirements.txt
@@ -5,3 +5,4 @@ GitPython
 langchain
 google-generativeai
 langchain-google-genai
+requests

--- a/refactor/src/business_logic/refactor_pipeline.py
+++ b/refactor/src/business_logic/refactor_pipeline.py
@@ -1,8 +1,10 @@
 from typing import List, Dict
 import shutil
 import os
-from common.utils.repo_utils import clone_repo
 from datetime import datetime
+import requests
+
+from common.utils.repo_utils import clone_repo
 from .file_extraction import extract_code_from_files
 from .gemini_refactor import refactor_code_using_gemini
 
@@ -22,6 +24,45 @@ def save_refactored_code(repo_path: str, refactored_code: Dict[str, str]):
             print(f"Successfully saved refactored code to {full_path}")
         except Exception as e:
             print(f"Error saving file {full_path}: {e}")
+
+
+def create_pull_request(repo_url: str, head: str, base: str):
+    """Create a pull request on GitHub for the refactored branch.
+
+    Args:
+        repo_url: URL of the repository on GitHub.
+        head: Name of the branch containing the changes.
+        base: Name of the branch to merge into.
+    """
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN not set; skipping pull request creation.")
+        return
+
+    try:
+        path = repo_url.rstrip("/").replace(".git", "").split("github.com/")[-1]
+        owner, repo = path.split("/", 1)
+    except ValueError:
+        print(f"Unable to parse owner and repo from URL: {repo_url}")
+        return
+
+    api_url = f"https://api.github.com/repos/{owner}/{repo}/pulls"
+    headers = {"Authorization": f"token {token}"}
+    data = {
+        "title": "AI-powered refactoring",
+        "head": head,
+        "base": base,
+        "body": "Automated refactoring via Gemini",
+    }
+    try:
+        response = requests.post(api_url, headers=headers, json=data, timeout=10)
+        if response.status_code in (200, 201):
+            pr_url = response.json().get("html_url")
+            print(f"Created pull request: {pr_url}")
+        else:
+            print(f"Failed to create pull request: {response.status_code} {response.text}")
+    except Exception as e:
+        print(f"Error while creating pull request: {e}")
 
 def run(repo_url: str, branch: str, files: List[str]):
     """
@@ -56,7 +97,7 @@ def run(repo_url: str, branch: str, files: List[str]):
             origin = repo.remote(name='origin')
             origin.push(new_branch_name)
             print(f"Pushed changes to branch {new_branch_name}")
-            print(f"Please create a pull request for the branch '{new_branch_name}' manually.")
+            create_pull_request(repo_url, new_branch_name, branch)
         except Exception as e:
             print(f"Error committing or pushing changes: {e}")
     finally:

--- a/refactor/tests/test_refactor_pipeline.py
+++ b/refactor/tests/test_refactor_pipeline.py
@@ -15,10 +15,11 @@ class TestRefactorPipeline(unittest.TestCase):
     @patch('refactor.src.business_logic.refactor_pipeline.extract_code_from_files')
     @patch('refactor.src.business_logic.refactor_pipeline.refactor_code_using_gemini')
     @patch('refactor.src.business_logic.refactor_pipeline.save_refactored_code')
+    @patch('refactor.src.business_logic.refactor_pipeline.create_pull_request')
     @patch('shutil.rmtree')
     @patch('os.path.exists', return_value=True)
     @patch('refactor.src.business_logic.refactor_pipeline.datetime')
-    def test_run_pipeline(self, mock_datetime, mock_exists, mock_rmtree, mock_save_refactored_code, mock_refactor_code, mock_extract_code, mock_clone_repo):
+    def test_run_pipeline(self, mock_datetime, mock_exists, mock_rmtree, mock_create_pr, mock_save_refactored_code, mock_refactor_code, mock_extract_code, mock_clone_repo):
         # Arrange
         mock_repo = MagicMock()
         mock_remote = MagicMock()
@@ -50,6 +51,7 @@ class TestRefactorPipeline(unittest.TestCase):
         mock_repo.git.add.assert_called_once_with(all=True)
         mock_repo.index.commit.assert_called_once_with("AI-powered refactoring")
         mock_remote.push.assert_called_once_with(expected_branch_name)
+        mock_create_pr.assert_called_once_with(repo_url, expected_branch_name, branch)
         mock_rmtree.assert_called_once_with('temp_dir')
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add GitHub pull request creation after automated refactor
- include requests dependency and update tests
- fix churn utilities path handling for forward slashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4e99ab9b8832888339421edcd6c2a